### PR TITLE
Sumo support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "readonly-rootfs-overlay"
 BBFILE_PATTERN_readonly-rootfs-overlay = "^${LAYERDIR}/"
 BBFILE_PRIORITY_readonly-rootfs-overlay = "6"
+
+LAYERSERIES_COMPAT_readonly-rootfs-overlay= "sumo rocko"

--- a/recipes-core/images/core-image-rorootfs-overlay-initramfs.bb
+++ b/recipes-core/images/core-image-rorootfs-overlay-initramfs.bb
@@ -3,12 +3,20 @@ DESCRIPTION = "Small image capable of booting a device. The kernel includes \
 the Minimal RAM-based Initial Root Filesystem (initramfs), mounts the root fs \
 read only and uses a file system overlay for written data."
 
-PACKAGE_INSTALL = "initramfs-readonly-rootfs-overlay ${VIRTUAL-RUNTIME_base-utils} udev base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
+INITRAMFS_SCRIPTS ?= "\
+                      initramfs-framework-base \
+                      initramfs-module-setup-live \
+                      initramfs-module-udev \
+                      initramfs-module-install \
+                      initramfs-module-install-efi \
+                     "
+
+PACKAGE_INSTALL = "initramfs-readonly-rootfs-overlay ${INITRAMFS_SCRIPTS} ${VIRTUAL-RUNTIME_base-utils} udev base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
 
 # Do not pollute the initrd image with rootfs features
 IMAGE_FEATURES = ""
 
-export IMAGE_BASENAME = "core-image-readonly-rootfs-overlay-initramfs"
+export IMAGE_BASENAME = "${MLPREFIX}core-image-rorootfs-overlay-initramfs"
 IMAGE_LINGUAS = ""
 
 LICENSE = "MIT"
@@ -20,3 +28,6 @@ IMAGE_ROOTFS_SIZE = "8192"
 IMAGE_ROOTFS_EXTRA_SPACE = "0"
 
 BAD_RECOMMENDATIONS += "busybox-syslog"
+
+# Use the same restriction as initramfs-live-install
+COMPATIBLE_HOST = "(i.86|x86_64).*-linux"

--- a/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
+++ b/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
@@ -23,8 +23,8 @@ ROOT_ROMOUNTOPTIONS="bind"
 ROOT_ROMOUNTOPTIONS_DEVICE="noatime,nodiratime"
 
 ROOT_RWFSTYPE=""
-ROOT_RWMOUNTOPTIONS="rw,noatime,mode=755 tmpfs"
-ROOT_RWMOUNTOPTIONS_DEVICE="rw,noatime,mode=755"
+ROOT_RWMOUNTOPTIONS="rw,noatime tmpfs"
+ROOT_RWMOUNTOPTIONS_DEVICE="rw,noatime"
 
 early_setup() {
 	mkdir -p /proc

--- a/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
+++ b/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
@@ -91,7 +91,13 @@ mount_and_boot() {
 	# current root file system via bind mount.
 	ROOT_ROMOUNTPARAMS_BIND="-o ${ROOT_ROMOUNTOPTIONS} /"
 	if [ -n "${ROOT_RODEVICE}" ]; then
-		ROOT_ROMOUNTPARAMS="-o ${ROOT_ROMOUNTOPTIONS_DEVICE} $ROOT_RODEVICE"
+		ROOT_ROPARTUUID=$(echo ${ROOT_RODEVICE} | awk -F= '/PARTUUID/ {print $NF}')
+		if [ -n "${ROOT_ROPARTUUID}" ]; then
+			ROOT_ROMOUNTPARAMS="-o ${ROOT_ROMOUNTOPTIONS_DEVICE} $(blkid | awk -F: "/${ROOT_ROPARTUUID}/ { print \$1}")"
+		else
+			ROOT_ROMOUNTPARAMS="-o ${ROOT_ROMOUNTOPTIONS_DEVICE} $ROOT_RODEVICE"
+		fi
+
 		if [ -n "${ROOT_ROFSTYPE}" ]; then
 			ROOT_ROMOUNTPARAMS="-t $ROOT_ROFSTYPE $ROOT_ROMOUNTPARAMS"
 		fi
@@ -124,8 +130,13 @@ mount_and_boot() {
 	# If a read-write device was specified via kernel command line, use
 	# it, otherwise default to tmpfs.
 	if [ -n "${ROOT_RWDEVICE}" ]; then
-		
-		ROOT_RWMOUNTPARAMS="-o $ROOT_RWMOUNTOPTIONS_DEVICE $ROOT_RWDEVICE"
+		ROOT_RWPARTUUID=$(echo ${ROOT_RWDEVICE} | awk -F= '/PARTUUID/ {print $NF}')
+		if [ -n "${ROOT_RWPARTUUID}" ]; then
+			ROOT_RWMOUNTPARAMS="-o ${ROOT_RWMOUNTOPTIONS_DEVICE} $(blkid | awk -F: "/${ROOT_RWPARTUUID}/ { print \$1}")"
+		else
+			ROOT_RWMOUNTPARAMS="-o $ROOT_RWMOUNTOPTIONS_DEVICE $ROOT_RWDEVICE"
+		fi
+
 		if [ -n "${ROOT_RWFSTYPE}" ]; then
 			ROOT_RWMOUNTPARAMS="-t $ROOT_RWFSTYPE $ROOT_RWMOUNTPARAMS"
 		fi


### PR DESCRIPTION
I have updated this layer to be usable in distro based on sumo branch.

Furthermore, busybox `mount` supports path and device UUID but not partition UUID.
This done by extracting partition UUID from the `root` and the `rootrw` cmdline parameters and resolve to the actual device using `blkid`