### PR TITLE
boot: do not bind mount rofs.

### DIFF
--- a/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
+++ b/recipes-core/initrdscripts/files/init-readonly-rootfs-overlay-boot.sh
@@ -101,10 +101,7 @@ mount_and_boot() {
 
 	# Mount root file system to new mount-point, if unsuccessful, try bind
 	# mounting current root file system.
-	if ! $MOUNT $ROOT_ROMOUNTPARAMS "$ROOT_ROMOUNT" 2>/dev/null && \
-		[ "x$ROOT_ROMOUNTPARAMS_BIND" == "x$ROOT_ROMOUNTPARAMS" ] || \
-		log "Could not mount $ROOT_RODEVICE, bind mounting..." && \
-		! $MOUNT $ROOT_ROMOUNTPARAMS_BIND "$ROOT_ROMOUNT"; then
+	if ! $MOUNT $ROOT_ROMOUNTPARAMS "$ROOT_ROMOUNT" ; then
 		fatal "Could not mount read-only rootfs"
 	fi
 


### PR DESCRIPTION
The read-only bind mount logic does not work properly and the system panic as the bind mount operation failed.
```
rorootfs-overlay: Could not mount PARTUUID=e7015e0b-c7e3-4f70-a483-f9bc2d7e8fda, bind mounting...
EXT4-fs (sda4): mounted filesystem with ordered data mode. Opts: (null)
chroot: can't execute '/sbin/init': No such file or directory
Kernel panic - not syncing: Attempted to kill init! exitcode=0x00007f00
```
I have removed the bind mount logic and the overlay is prepared properly where the read-only filesystem is mounted from `root=` and `rootrw=` is mounted read-write as overlayfs. When no `rootrw=` is given an ad-hoc `tmpfs` is created.