### PR TITLE
Init overlay workaournd with DNF

### DIFF
--- a/recipes-core/initrdscripts/readonly-rootfs-overlay-init-script.inc
+++ b/recipes-core/initrdscripts/readonly-rootfs-overlay-init-script.inc
@@ -7,12 +7,12 @@ SRC_URI = "file://init-readonly-rootfs-overlay-boot.sh"
 S = "${WORKDIR}"
 
 do_install() {
-        install -m 0755 ${WORKDIR}/init-readonly-rootfs-overlay-boot.sh ${D}/init
+        install -m 0755 ${WORKDIR}/init-readonly-rootfs-overlay-boot.sh ${D}/init-overlay
         install -d "${D}/media/rfs/ro"
         install -d "${D}/media/rfs/rw"
 }
 
-FILES_${PN} += " /init /media/rfs"
+FILES_${PN} += " /init-overlay /media/rfs"
 
 # Due to kernel dependency
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Package management based on DNF has more in-depth checks compared to APT.
Building a initramfs fails with the following error message:
```
Transaction Summary
================================================================================
Install  37 Packages

Total size: 5.2 M
Installed size: 22 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Error: Transaction check error:
  file /init conflicts between attempted installs of initramfs-readonly-rootfs-overlay-1.0-r0.intel_corei7_64 and initramfs-framework-base``-1.0-r4.noarch

Error Summary
-------------


DEBUG: Python function do_rootfs finished
ERROR: Function failed: do_rootfs
```
I worked around this issue I have renamed the init script to `init-overlay` to not clash with the `init` script provided by the `initramfs-framework-base` recipe.

To finalize it, the `rdinit=/init-overlay` argument must be passed as a kernel parameter to start the right initramfs init script on boot.