### PR TITLE
initramfs: evict /init from initramfs framework

### DIFF
--- a/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,0 +1,5 @@
+do_install_append () {
+    rm ${D}/init
+}
+
+FILES_${PN}_remove = "/init"


### PR DESCRIPTION
This changeset removes the file `/init` from the `initramfs-framework` recipe to avoid file collisions.
Such collision prevents RPM-based package managed distro to build their rootfs.
This fix deprecates the one submitted in #9