### PR TITLE
Add rocko, thud, warrior, zeus, dunfell, gatesgarth and hardknott to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "readonly-rootfs-overlay"
 BBFILE_PATTERN_readonly-rootfs-overlay = "^${LAYERDIR}/"
 BBFILE_PRIORITY_readonly-rootfs-overlay = "6"
 
-LAYERSERIES_COMPAT_readonly-rootfs-overlay = "sumo"
+LAYERSERIES_COMPAT_readonly-rootfs-overlay = "rocko sumo thud"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "readonly-rootfs-overlay"
 BBFILE_PATTERN_readonly-rootfs-overlay = "^${LAYERDIR}/"
 BBFILE_PRIORITY_readonly-rootfs-overlay = "6"
 
-LAYERSERIES_COMPAT_readonly-rootfs-overlay = "rocko sumo thud warrior"
+LAYERSERIES_COMPAT_readonly-rootfs-overlay = "rocko sumo thud warrior zeus dunfell gatesgarth"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "readonly-rootfs-overlay"
 BBFILE_PATTERN_readonly-rootfs-overlay = "^${LAYERDIR}/"
 BBFILE_PRIORITY_readonly-rootfs-overlay = "6"
 
-LAYERSERIES_COMPAT_readonly-rootfs-overlay = "rocko sumo thud"
+LAYERSERIES_COMPAT_readonly-rootfs-overlay = "rocko sumo thud warrior"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "readonly-rootfs-overlay"
 BBFILE_PATTERN_readonly-rootfs-overlay = "^${LAYERDIR}/"
 BBFILE_PRIORITY_readonly-rootfs-overlay = "6"
 
-LAYERSERIES_COMPAT_readonly-rootfs-overlay = "rocko sumo thud warrior zeus dunfell gatesgarth"
+LAYERSERIES_COMPAT_readonly-rootfs-overlay = "rocko sumo thud warrior zeus dunfell gatesgarth hardknott"


### PR DESCRIPTION
https://github.com/cmhe/meta-readonly-rootfs-overlay/commit/735aba8682471193d631eb08602b772b6c41cbb7 breaks compatibility with rocko and thud. The fix is to add these also to LAYERSERIES_COMPAT.

Please also add a honister branch: https://github.com/johannesschrimpf/meta-readonly-rootfs-overlay/tree/honister

This can't be merged into master since the syntax changed.